### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/dmerchant0289/4303d8b8-c9ab-437f-b315-bc4d2a0a7007/dc200886-60bf-461c-aad1-f086d511e7bc/_apis/work/boardbadge/9fb833d2-0653-498e-93ad-1b367d201c94)](https://dev.azure.com/dmerchant0289/4303d8b8-c9ab-437f-b315-bc4d2a0a7007/_boards/board/t/dc200886-60bf-461c-aad1-f086d511e7bc/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dmerchant0289/4303d8b8-c9ab-437f-b315-bc4d2a0a7007/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.